### PR TITLE
Feat/header icons and text

### DIFF
--- a/src/components/grid/ColumnHeader.tsx
+++ b/src/components/grid/ColumnHeader.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import {
-  IconBox,
-  IconClock,
+  // IconBox,
+  // IconClock,
   IconKey,
-  IconType,
+  // IconType,
+  // IconHash,
+  // IconCheckCircle,
+  // IconList,
+  // IconCalendar,
   IconLink,
-  IconHash,
-  IconCheckCircle,
-  IconList,
-  IconCalendar,
 } from '@supabase/ui';
 import { useDrag, useDrop, DropTargetMonitor } from 'react-dnd';
 import { XYCoord } from 'dnd-core';
@@ -17,7 +17,12 @@ import { useDispatch } from '../../store';
 import { ColumnHeaderProps, ColumnType, DragItem } from '../../types';
 import { ColumnMenu } from '../menu';
 
-export function ColumnHeader<R>({ column, columnType }: ColumnHeaderProps<R>) {
+export function ColumnHeader<R>({
+  column,
+  columnType,
+  isPrimaryKey,
+  format,
+}: ColumnHeaderProps<R>) {
   const ref = React.useRef<HTMLDivElement>(null);
   // const triggerRef = React.useRef<any>(null);
   const dispatch = useDispatch();
@@ -105,14 +110,22 @@ export function ColumnHeader<R>({ column, columnType }: ColumnHeaderProps<R>) {
   const cursor = column.frozen ? 'cursor-default' : '';
   drag(drop(ref));
 
+  console.log(column.name, columnType);
+
   return (
     <div ref={ref} data-handler-id={handlerId} style={{ opacity }}>
       <SortableHeaderCell column={column}>
-        <div className={`flex items-center ${cursor}`}>
-          {renderColumnIcon(columnType)}
-          <span className="inline-block ml-2 flex-grow overflow-hidden overflow-ellipsis text-sm">
-            {column.name}
-          </span>
+        <div className={`flex items-center ${cursor} justify-between`}>
+          <div className="flex items-center space-x-2 rdg-header-row__content">
+            {renderColumnIcon(columnType)}
+            {isPrimaryKey && (
+              <div className="transform rotate-45 flex items-center">
+                <IconKey size="tiny" strokeWidth={2} />
+              </div>
+            )}
+            <span className="rdg-header-row__content__name">{column.name}</span>
+            <span className="rdg-header-row__content__format">{format}</span>
+          </div>
           <ColumnMenu column={column} />
         </div>
       </SortableHeaderCell>
@@ -122,26 +135,26 @@ export function ColumnHeader<R>({ column, columnType }: ColumnHeaderProps<R>) {
 
 function renderColumnIcon(type: ColumnType) {
   switch (type) {
-    case 'boolean':
-      return <IconCheckCircle size="tiny" />;
-    case 'date':
-      return <IconCalendar size="tiny" />;
-    case 'datetime':
-      return <IconClock size="tiny" />;
-    case 'time':
-      return <IconClock size="tiny" />;
-    case 'enum':
-      return <IconList size="tiny" />;
+    // case 'primary_key':
+    //   return <IconKey size="tiny" />;
+    // case 'boolean':
+    //   return <IconCheckCircle size="tiny" />;
+    // case 'date':
+    //   return <IconCalendar size="tiny" />;
+    // case 'datetime':
+    //   return <IconClock size="tiny" />;
+    // case 'time':
+    //   return <IconClock size="tiny" />;
+    // case 'enum':
+    //   return <IconList size="tiny" />;
     case 'foreign_key':
-      return <IconLink size="tiny" />;
-    case 'json':
-      return <IconBox size="tiny" />;
-    case 'number':
-      return <IconHash size="tiny" />;
-    case 'primary_key':
-      return <IconKey size="tiny" />;
-    case 'text':
-      return <IconType size="tiny" />;
+      return <IconLink size="tiny" strokeWidth={2} />;
+    // case 'json':
+    //   return <IconBox size="tiny" />;
+    // case 'number':
+    //   return <IconHash size="tiny" />;
+    // case 'text':
+    //   return <IconType size="tiny" />;
     default:
       return null;
   }

--- a/src/style.css
+++ b/src/style.css
@@ -72,12 +72,30 @@
   line-height: var(--header-row-height);
   top: 0;
 }
-.rdg-header-row .rdg-cell {
-  @apply bg-table-header-light dark:bg-table-header-dark border-b dark:border-dark;
+
+.rdg-header-row__content__name {
+  @apply overflow-hidden overflow-ellipsis text-sm;
   @apply text-typography-body-light dark:text-typography-body-dark;
 }
+
+.rdg-header-row__content__format {
+  @apply text-xs;
+  @apply font-normal overflow-hidden overflow-ellipsis;
+  @apply text-typography-body-secondary-light dark:text-typography-body-secondary-dark;
+}
+
+.rdg-header-row__content svg {
+  @apply mr-1;
+  @apply text-green-500 border-green-500 dark:text-green-500 dark:border-green-500;
+}
+
+.rdg-header-row .rdg-cell {
+  @apply bg-table-header-light dark:bg-table-header-dark border-b dark:border-dark;
+  /* @apply text-typography-body-light dark:text-typography-body-dark; */
+}
 .rdg-header-row .rdg-cell p,
-.rdg-header-row .rdg-cell svg {
+/* .rdg-cell svg  */
+ {
   @apply text-typography-body-light dark:text-typography-body-dark;
 }
 .rdg-header-row .rdg-cell .react-contextmenu-wrapper {
@@ -130,7 +148,7 @@
 }
 
 .rdg-row .rdg-cell span,
-.rdg-row .rdg-cell svg,
+/* .rdg-row .rdg-cell svg, */
 .rdg-row .rdg-cell div {
   @apply text-typography-body-light dark:text-typography-body-dark;
 }

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -43,4 +43,6 @@ export type ColumnType =
 
 export interface ColumnHeaderProps<R> extends HeaderRendererProps<R> {
   columnType: ColumnType;
+  isPrimaryKey: Boolean | undefined;
+  format: string;
 }

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -27,4 +27,5 @@ export interface SupaTable {
 
 export interface SupaRow extends Dictionary<any> {
   readonly idx: number;
+  readonly isPrimaryKey?: boolean;
 }

--- a/src/utils/gridColumns.tsx
+++ b/src/utils/gridColumns.tsx
@@ -35,8 +35,17 @@ export function getGridColumns(
     };
     const columnType = _getColumnType(x);
 
+    console.log(x);
+
     columnDef.headerRenderer = props => {
-      return <ColumnHeader {...props} columnType={columnType} />;
+      return (
+        <ColumnHeader
+          {...props}
+          columnType={columnType}
+          isPrimaryKey={x.isPrimaryKey}
+          format={x.format}
+        />
+      );
     };
 
     _setupColumnEditor(x, columnType, columnDef);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -87,7 +87,11 @@ module.exports = {
         */
         'typography-body': {
           light: coolGray[600],
-          dark: gray[200],
+          dark: gray[100],
+        },
+        'typography-body-secondary': {
+          light: coolGray[400],
+          dark: gray[300],
         },
 
         /*


### PR DESCRIPTION
• replaced icons with `format` of column so you can see difference of number and date columns
• added icons for `primary_key` and `foreign_key` so it's easy to see those columns

![Screenshot 2021-05-27 at 16 25 42](https://user-images.githubusercontent.com/8291514/119792329-308b2100-bf08-11eb-93ba-a1081879e196.png)
