### PR TITLE
ptch: change formatting for null/empty text column

### DIFF
--- a/src/components/common/EmptyValue.tsx
+++ b/src/components/common/EmptyValue.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+type EmptyValueProps = {};
+
+export const EmptyValue: React.FC<EmptyValueProps> = ({}) => {
+  return <span className="block">EMPTY</span>;
+};

--- a/src/components/common/NullValue.tsx
+++ b/src/components/common/NullValue.tsx
@@ -3,5 +3,5 @@ import * as React from 'react';
 type NullValueProps = {};
 
 export const NullValue: React.FC<NullValueProps> = ({}) => {
-  return <span className="block">[null]</span>;
+  return <span className="block">NULL</span>;
 };

--- a/src/components/formatter/DefaultFormatter.tsx
+++ b/src/components/formatter/DefaultFormatter.tsx
@@ -2,12 +2,14 @@ import * as React from 'react';
 import { FormatterProps } from '@supabase/react-data-grid';
 import { SupaRow } from '../../types';
 import { NullValue } from '../common';
+import { EmptyValue } from '../common/EmptyValue';
 
 export const DefaultFormatter = (
   p: React.PropsWithChildren<FormatterProps<SupaRow, unknown>>
 ) => {
   let value = p.row[p.column.key];
   if (value === null) return <NullValue />;
+  if(value === '') return <EmptyValue />;
   if (typeof value == 'object' || Array.isArray(value)) {
     value = JSON.stringify(value);
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Patch

## What is the current behavior?
![image](https://user-images.githubusercontent.com/23580602/121581280-48f05500-ca4b-11eb-8a97-7ea9a79b5766.png)

Closes https://github.com/supabase/grid/issues/42

## What is the new behavior?
```sql
update profile set test = NULL;
```
![image](https://user-images.githubusercontent.com/23580602/121581381-632a3300-ca4b-11eb-8e0b-c9d2eacaff28.png)
```sql
update profile set test = '';
```
![image](https://user-images.githubusercontent.com/23580602/121581589-9a98df80-ca4b-11eb-8f04-36367ffdd6bc.png)

