### PR TITLE
fix: add support for null value in boolean editor

### DIFF
--- a/src/components/editor/BooleanEditor.tsx
+++ b/src/components/editor/BooleanEditor.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { EditorProps } from '@supabase/react-data-grid';
+
+
+export function BooleanEditor<TRow, TSummaryRow = unknown>({
+  row,
+  column,
+  onRowChange,
+  onClose,
+}: EditorProps<TRow, TSummaryRow>) {
+  const value = (row[column.key as keyof TRow] as unknown) as string | null;
+
+  function onChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    const value = event.target.value;
+    if (!value || value == '') {
+      onRowChange({ ...row, [column.key]: null }, true);
+    } else {
+      onRowChange({ ...row, [column.key]: JSON.parse(value) }, true);
+    }
+  }
+
+  function onBlur() {
+    onClose(false);
+  }
+
+  return (
+    <select
+      className="sb-grid-select-editor"
+      value={value ?? ''}
+      onChange={onChange}
+      onBlur={onBlur}
+      autoFocus
+    >
+      <option value={''}>[null]</option>
+      <option value="true">True</option>
+      <option value="false">True</option>
+    </select>
+  );
+}

--- a/src/components/editor/index.ts
+++ b/src/components/editor/index.ts
@@ -6,3 +6,4 @@ export * from './NumberEditor';
 export * from './SelectEditor';
 export * from './TextEditor';
 export * from './TimeEditor';
+export * from './BooleanEditor';

--- a/src/components/formatter/BooleanFormatter.tsx
+++ b/src/components/formatter/BooleanFormatter.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { FormatterProps } from '@supabase/react-data-grid';
+import { NullValue } from '../common';
 import { SupaRow } from '../../types';
 
 export const BooleanFormatter = (
   p: React.PropsWithChildren<FormatterProps<SupaRow, unknown>>
 ) => {
-  const value = p.row[p.column.key] as boolean;
-  return <>{value ? 'true' : 'false'}</>;
+  const value = p.row[p.column.key] as boolean | null;
+  return <>{value === null ? <NullValue /> : value ? 'true' : 'false'}</>;
 };

--- a/src/utils/gridColumns.tsx
+++ b/src/utils/gridColumns.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Column } from '@supabase/react-data-grid';
 import { ColumnType, SupaColumn, SupaRow, SupaTable } from '../types';
 import {
-  CheckboxEditor,
+  BooleanEditor,
   DateEditor,
   DateTimeEditor,
   JsonEditor,
@@ -84,7 +84,7 @@ function _setupColumnEditor(
 
   switch (columnType) {
     case 'boolean': {
-      config.editor = CheckboxEditor;
+      config.editor = BooleanEditor;
       break;
     }
     case 'date': {


### PR DESCRIPTION
Bugfix, fixes: #57 

Created a new boolean editor, which is select, so that it allows null, true and false as options to it.
