### PR TITLE
chore: display total rows count in pagination footer

### DIFF
--- a/src/components/footer/pagination/Pagination.tsx
+++ b/src/components/footer/pagination/Pagination.tsx
@@ -108,6 +108,7 @@ const Pagination: React.FC<PaginationProps> = () => {
           style={{ padding: '3px 10px' }}
         >{`${state.rowsPerPage} rows`}</Button>
       </DropdownControl>
+      <Typography.Text>{state.totalRows.toLocaleString()} records</Typography.Text>
     </div>
   );
 };


### PR DESCRIPTION
closes: #19 

This PR allows displaying the total count of rows in the footer of the grid.