### PR TITLE
Fix optional chaining in copy shortcut

### DIFF
--- a/src/components/common/Shortcuts.tsx
+++ b/src/components/common/Shortcuts.tsx
@@ -73,7 +73,7 @@ export function Shortcuts({ gridRef }: ShortcutsProps) {
           const { idx, rowIdx } = selectedCellPosition;
           if (idx > 0) {
             const colKey = gridColumns[idx].key;
-            const cellValue = rows[rowIdx][colKey] ?? '';
+            const cellValue = rows[rowIdx]?.[colKey] ?? '';
             const value = formatClipboardValue(cellValue);
             navigator.clipboard.writeText(value);
           }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Resolves https://sentry.io/organizations/supabase/issues/2659441479/?project=5459134&referrer=slack

But @phamhieu we might need to check why `rowIdx` is referring to an undefined row from `rows` though