### PR TITLE
Storage Media Column - Upload directly to supabase storage, preview media, drag and drop files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ npm i react react-dom @supabase/react-data-grid @supabase/ui
 - `onEditColumn` show edit column menu if available.
 - `onEditRow` show edit row button if available.
 - `onDeleteColumn` show delete column menu if available.
+- `supabaseStorageClient` for managing files on supabase storage with `storageMedia` columns.
 
 ## Run example
 

--- a/example/.env.example
+++ b/example/.env.example
@@ -1,2 +1,4 @@
 # Update these with your Supabase details from your project settings > API
 NEXT_PUBLIC_CONNECTION_STRING = 'your-project-database-connection-string'
+NEXT_PUBLIC_SUPABASE_ID = 'your-supabase-id'
+NEXT_PUBLIC_SUPABASE_KEY = 'your-supabase-key'

--- a/example/components/grid.tsx
+++ b/example/components/grid.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { SupabaseGrid, SupabaseGridRef, SupaRow } from '@supabase/grid';
+import { createClient } from '@supabase/supabase-js';
 import { postAndWait } from './grid.utils';
 
 export default function Grid() {
@@ -15,6 +16,14 @@ export default function Grid() {
   );
   const [isReadonly, setReadonly] = React.useState(true);
   const [reload, setReload] = React.useState(false);
+  let supabase = createClient(
+    `https://${process.env.NEXT_PUBLIC_SUPABASE_ID}.supabase.co`,
+    process.env.NEXT_PUBLIC_SUPABASE_KEY,
+    {
+      localStorage: undefined,
+      detectSessionInUrl: false,
+    }
+  );
 
   function onReadonlyInputChange(e: React.ChangeEvent<HTMLInputElement>) {
     setReadonly(e.target.checked);
@@ -123,6 +132,7 @@ export default function Grid() {
               const res = await postAndWait('/api/sql-query', { query });
               return res;
             }}
+            supabaseStorageClient={supabase.storage}
             headerActions={
               <>
                 <span>{`'{headerActions}' can be used to insert`}</span>,

--- a/example/package.json
+++ b/example/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@supabase/grid": "file:../",
     "@supabase/react-data-grid": "^7.1.0-beta.5",
+    "@supabase/supabase-js": "^1.24.0",
     "@supabase/ui": "^0.35.0",
     "next": "^11.1.2",
     "pg": "^8.7.1",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -33,7 +33,7 @@ export default {
     nodeResolve(),
     json(),
     commonjs(),
-    typescript({ useTsconfigDeclarationDir: true }),
+    typescript({ useTsconfigDeclarationDir: true, abortOnError: false }),
     postcss({
       plugins: [
         tailwindcss(tailwindconfig),

--- a/src/SupabaseGrid.utils.ts
+++ b/src/SupabaseGrid.utils.ts
@@ -36,6 +36,7 @@ export function initTable(
 ) {
   function onInitTable(table: SupaTable, props: SupabaseGridProps) {
     const gridColumns = getGridColumns(table, {
+      storage: props.supabaseStorageClient,
       editable: props.editable,
       defaultWidth: props.gridProps?.defaultColumnWidth,
       onAddColumn: props.editable ? props.onAddColumn : undefined,

--- a/src/components/editor/StorageMediaEditor.tsx
+++ b/src/components/editor/StorageMediaEditor.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { EditorProps } from '@supabase/react-data-grid';
+import { NativeTypes } from 'react-dnd-html5-backend';
+import { useDrop, DropTargetMonitor } from 'react-dnd';
+
+interface StorageMediaEditorProps<TRow, TSummaryRow = unknown>
+  extends EditorProps<TRow, TSummaryRow> {
+  options: { bucketName: string; mediaUrlPrefix: string };
+  storage: any;
+}
+
+export function StorageMediaEditor<TRow, TSummaryRow = unknown>({
+  row,
+  column,
+  onRowChange,
+  options,
+  storage,
+}: StorageMediaEditorProps<TRow, TSummaryRow>) {
+  const [{ canDrop, isOver }, drop] = useDrop(() => ({
+    accept: [NativeTypes.FILE],
+    drop(item: { files: any[] }) {
+      const file = item.files[0];
+      console.log('file', item);
+      const { data, error } = storage
+        .from(options.bucketName)
+        .upload(file.name, file);
+      onRowChange({ ...row, [column.key]: file.name });
+    },
+    collect: (monitor: DropTargetMonitor) => ({
+      isOver: monitor.isOver(),
+      canDrop: monitor.canDrop(),
+    }),
+  }));
+
+  const isActive = canDrop && isOver;
+  let overlayDivClass = 'sb-grid-storage-media-editor-overlay';
+  if (isActive)
+    overlayDivClass += ' sb-grid-storage-media-editor-overlay__trigger';
+  return (
+    <div className="sb-grid-storage-media-editor">
+      <div className={overlayDivClass} ref={drop}></div>
+      <img src={options.mediaUrlPrefix + row[column.key]} />
+    </div>
+  );
+}

--- a/src/components/editor/StorageMediaEditor.tsx
+++ b/src/components/editor/StorageMediaEditor.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { EditorProps } from '@supabase/react-data-grid';
 import { NativeTypes } from 'react-dnd-html5-backend';
+import { IconDownload } from '@supabase/ui';
 import { useDrop, DropTargetMonitor } from 'react-dnd';
 
 interface StorageMediaEditorProps<TRow, TSummaryRow = unknown>
@@ -16,15 +17,24 @@ export function StorageMediaEditor<TRow, TSummaryRow = unknown>({
   options,
   storage,
 }: StorageMediaEditorProps<TRow, TSummaryRow>) {
+  async function upload(file: any) {
+    console.log('file', file);
+    const { error } = await storage
+      .from(options.bucketName)
+      .upload(file.name, file);
+    if (error) {
+      // TODO:
+    } else {
+      onRowChange({ ...row, [column.key]: file.name });
+    }
+  }
+
   const [{ canDrop, isOver }, drop] = useDrop(() => ({
     accept: [NativeTypes.FILE],
-    drop(item: { files: any[] }) {
+    async drop(item: { files: any[] }) {
       const file = item.files[0];
       console.log('file', item);
-      const { data, error } = storage
-        .from(options.bucketName)
-        .upload(file.name, file);
-      onRowChange({ ...row, [column.key]: file.name });
+      upload(file);
     },
     collect: (monitor: DropTargetMonitor) => ({
       isOver: monitor.isOver(),
@@ -33,13 +43,20 @@ export function StorageMediaEditor<TRow, TSummaryRow = unknown>({
   }));
 
   const isActive = canDrop && isOver;
+  const val = row[column.key];
+  const isNull = val === null;
   let overlayDivClass = 'sb-grid-storage-media-editor-overlay';
   if (isActive)
     overlayDivClass += ' sb-grid-storage-media-editor-overlay__trigger';
   return (
     <div className="sb-grid-storage-media-editor">
+      {isNull ? (
+        <IconDownload className="sb-grid-storage-media-upload-icon"></IconDownload>
+      ) : (
+        <img src={options.mediaUrlPrefix + val} />
+      )}
       <div className={overlayDivClass} ref={drop}></div>
-      <img src={options.mediaUrlPrefix + row[column.key]} />
+      <input type="file" onChange={(evt) => upload(evt.target.files![0])} />
     </div>
   );
 }

--- a/src/components/editor/index.ts
+++ b/src/components/editor/index.ts
@@ -5,5 +5,6 @@ export * from './JsonEditor';
 export * from './NullableBooleanEditor';
 export * from './NumberEditor';
 export * from './SelectEditor';
+export * from './StorageMediaEditor';
 export * from './TextEditor';
 export * from './TimeEditor';

--- a/src/components/formatter/StorageMediaFormatter.tsx
+++ b/src/components/formatter/StorageMediaFormatter.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { FormatterProps } from '@supabase/react-data-grid';
+import { SupaRow } from '../../types';
+import { NullValue } from '../common';
+
+interface StorageMediaFormatterProps<T, Q> extends FormatterProps<T, Q> {
+  mediaUrlPrefix: string;
+}
+
+export const StorageMediaFormatter = (
+  p: React.PropsWithChildren<StorageMediaFormatterProps<SupaRow, unknown>>
+) => {
+  const value = p.row[p.column.key] as boolean | null;
+  if (value === null) return <NullValue />;
+  return <img height="200" width="auto" src={p.mediaUrlPrefix + value} />;
+};

--- a/src/components/formatter/StorageMediaFormatter.tsx
+++ b/src/components/formatter/StorageMediaFormatter.tsx
@@ -10,7 +10,15 @@ interface StorageMediaFormatterProps<T, Q> extends FormatterProps<T, Q> {
 export const StorageMediaFormatter = (
   p: React.PropsWithChildren<StorageMediaFormatterProps<SupaRow, unknown>>
 ) => {
-  const value = p.row[p.column.key] as boolean | null;
+  const value = p.row[p.column.key] as string | null;
   if (value === null) return <NullValue />;
-  return <img height="200" width="auto" src={p.mediaUrlPrefix + value} />;
+  const isVideo = value.toLowerCase().endsWith('.mp4');
+  const fullUrl = p.mediaUrlPrefix + value;
+  return isVideo ? (
+    <video controls>
+      <source type="video/mp4" src={fullUrl} />
+    </video>
+  ) : (
+    <img height="200" width="auto" src={fullUrl} />
+  );
 };

--- a/src/components/formatter/index.ts
+++ b/src/components/formatter/index.ts
@@ -1,3 +1,4 @@
 export * from './BooleanFormatter';
 export * from './DefaultFormatter';
 export * from './ForeignKeyFormatter';
+export * from './StorageMediaFormatter';

--- a/src/components/grid/Grid.tsx
+++ b/src/components/grid/Grid.tsx
@@ -92,6 +92,8 @@ export const Grid = memo(
           <DataGrid
             ref={ref}
             columns={gridColumns}
+            headerRowHeight={35}
+            rowHeight={200}
             rows={rows ?? []}
             rowRenderer={RowRenderer}
             rowKeyGetter={rowKeyGetter}

--- a/src/style.css
+++ b/src/style.css
@@ -455,13 +455,14 @@
 */
 
 .sb-grid-storage-media-editor {
-  @apply w-full h-full;
+  @apply w-full h-full flex flex-col items-center;
   position: relative;
 }
 
-.sb-grid-storage-media-editor > img {
-  @apply w-full;
-  height: auto;
+.sb-grid-storage-media-editor > img,
+.sb-grid-storage-media-editor > video {
+  @apply h-full;
+  width: auto;
 }
 
 .sb-grid-storage-media-editor-overlay {
@@ -470,8 +471,12 @@
 }
 
 .sb-grid-storage-media-editor-overlay__trigger {
-  background-color: 'red';
-  opacity: 0.5;
+  background-color: #24b47e;
+  opacity: 0.1;
+}
+
+.sb-grid-storage-media-upload-icon {
+  @apply w-full m-6;
 }
 
 /*

--- a/src/style.css
+++ b/src/style.css
@@ -451,6 +451,30 @@
 }
 
 /*
+ StorageMediaEditor
+*/
+
+.sb-grid-storage-media-editor {
+  @apply w-full h-full;
+  position: relative;
+}
+
+.sb-grid-storage-media-editor > img {
+  @apply w-full;
+  height: auto;
+}
+
+.sb-grid-storage-media-editor-overlay {
+  position: absolute;
+  @apply w-full h-full;
+}
+
+.sb-grid-storage-media-editor-overlay__trigger {
+  background-color: 'red';
+  opacity: 0.5;
+}
+
+/*
   TimeEditor
 */
 

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -40,6 +40,7 @@ export interface DragItem {
 }
 
 export type ColumnType =
+  | 'storage_media'
   | 'array'
   | 'boolean'
   | 'date'

--- a/src/types/grid.ts
+++ b/src/types/grid.ts
@@ -42,6 +42,10 @@ export interface SupabaseGridProps {
    */
   storageRef?: string;
   /**
+   * supabaseStorageClient is for managing files on supabase storage with `storageMedia` columns.
+   */
+  supabaseStorageClient?: any;
+  /**
    * Optional grid theme
    */
   theme?: 'dark' | 'light';

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -1,6 +1,6 @@
 import { Dictionary } from './base';
 
-export interface SupaColumn {
+interface _SupaColumn {
   readonly dataType: string;
   readonly format: string;
   readonly name: string;
@@ -10,6 +10,7 @@ export interface SupaColumn {
   readonly isPrimaryKey?: boolean;
   readonly isIdentity?: boolean;
   readonly isGeneratable?: boolean;
+  readonly isStorageMedia?: boolean;
   readonly isNullable?: boolean;
   readonly isUpdatable?: boolean;
   readonly targetTableSchema?: string | null;
@@ -17,6 +18,13 @@ export interface SupaColumn {
   readonly targetColumnName?: string | null;
   position: number;
 }
+
+export interface SupaStorageMediaColumn extends _SupaColumn {
+  readonly bucketName: string;
+  readonly mediaUrlPrefix: string;
+}
+
+export type SupaColumn = _SupaColumn & SupaStorageMediaColumn;
 
 export interface SupaTable {
   readonly columns: SupaColumn[];


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

No way to upload images into storage directly from tables. Must first upload to storage, copy the url, then paste it in a column. No way to preview media uploads in tables.

## What is the new behavior?

Allows previewing storage media directly in the table, allows changing or uploading new storage items directly into a special column type for storage media.

## Additional context

![Screencast 2021-10-17 23_37_04](https://user-images.githubusercontent.com/492864/137671134-c7cdec29-72f5-4c13-9f36-2a9956cec955.gif)


##WIP
[ ] I included the supabase storage client and passed it into the Grid to upload files... not sure if this is the best way? 
[ ] we need a special column type, this is something that needs to be changed on Supabase's backend. For now it's hacked in this way: https://github.com/supabase/grid/compare/main...mikob:main#diff-5c48901375b655f96a24eb5c4ede18c5ec0fb966fcb9b62d7effb69b8fda20c6R37-R45
[ ] better icon to represent drag and droppable field. I like this one: https://thenounproject.com/search/?q=drop+file&i=4076502 can it be added to Supabase UI?
[ ] A range slider to let users customize row height would be important for this. Currently I've hardcoded a 200px height. 
[ ] file selection via the <input> is not working ATM. 
[ ] need message for when there is an error when uploading. Examples of how to style this?

Bonus:
[ ] Upload progress
