### PR TITLE
add column order sync for gridColumns

### DIFF
--- a/src/components/grid/AddColumn.tsx
+++ b/src/components/grid/AddColumn.tsx
@@ -1,17 +1,21 @@
 import * as React from 'react';
-import { Column } from '@supabase/react-data-grid';
+import { CalculatedColumn } from '@supabase/react-data-grid';
 import { Button, IconPlus } from '@supabase/ui';
 import { ADD_COLUMN_KEY } from '../../constants';
 import { useTrackedState } from '../../store';
+import { DefaultFormatter } from '../formatter';
 
-export const AddColumn: Column<any, any> = {
+export const AddColumn: CalculatedColumn<any, any> = {
   key: ADD_COLUMN_KEY,
   name: '',
+  idx: 999,
   width: 100,
   maxWidth: 100,
   resizable: false,
   sortable: false,
   frozen: false,
+  isLastFrozenColumn: false,
+  rowGroup: false,
   headerRenderer(props) {
     return (
       <AddColumnHeader
@@ -21,6 +25,7 @@ export const AddColumn: Column<any, any> = {
       />
     );
   },
+  formatter: DefaultFormatter,
 };
 
 type SharedInputProps = Pick<

--- a/src/components/grid/ColumnHeader.tsx
+++ b/src/components/grid/ColumnHeader.tsx
@@ -5,6 +5,7 @@ import { XYCoord } from 'dnd-core';
 import { useDispatch } from '../../store';
 import { ColumnHeaderProps, ColumnType, DragItem } from '../../types';
 import { ColumnMenu } from '../menu';
+import { useTrackedState } from '../../store';
 
 export function ColumnHeader<R>({
   column,
@@ -17,6 +18,15 @@ export function ColumnHeader<R>({
   const columnIdx = column.idx;
   const columnKey = column.key;
   const columnFormat = getColumnFormat(columnType, format);
+  const state = useTrackedState();
+
+  // keep state.gridColumns' order in sync with data grid component
+  if (state.gridColumns[columnIdx].key != columnKey) {
+    dispatch({
+      type: 'UPDATE_COLUMN_IDX',
+      payload: { columnKey, columnIdx },
+    });
+  }
 
   const [{ isDragging }, drag] = useDrag({
     type: 'column-header',

--- a/src/components/grid/SelectColumn.tsx
+++ b/src/components/grid/SelectColumn.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  Column,
+  CalculatedColumn,
   FormatterProps,
   GroupFormatterProps,
   useRowSelection,
@@ -12,14 +12,17 @@ import { SELECT_COLUMN_KEY } from '../../constants';
 import { useFocusRef } from '../../utils';
 import { useTrackedState } from '../../store';
 
-export const SelectColumn: Column<any, any> = {
+export const SelectColumn: CalculatedColumn<any, any> = {
   key: SELECT_COLUMN_KEY,
   name: '',
+  idx: 0,
   width: 65,
   maxWidth: 65,
   resizable: false,
   sortable: false,
   frozen: true,
+  isLastFrozenColumn: false,
+  rowGroup: false,
   headerRenderer: props => {
     return (
       <SelectCellHeader

--- a/src/store/reducers/base.ts
+++ b/src/store/reducers/base.ts
@@ -1,4 +1,4 @@
-import { Column } from '@supabase/react-data-grid';
+import { CalculatedColumn } from '@supabase/react-data-grid';
 import { GridProps, SavedState, SupaTable } from '../../types';
 import { REFRESH_PAGE_IMMEDIATELY } from '../../constants';
 import { IRowService, SqlRowService } from '../../services/row';
@@ -33,7 +33,7 @@ export type INIT_ACTIONTYPE =
       type: 'INIT_TABLE';
       payload: {
         table: SupaTable;
-        gridColumns: Column<any, any>[];
+        gridColumns: CalculatedColumn<any, any>[];
         gridProps?: GridProps;
         savedState?: SavedState;
         editable?: boolean;

--- a/src/store/reducers/column.ts
+++ b/src/store/reducers/column.ts
@@ -1,10 +1,10 @@
 import update from 'immutability-helper';
-import { Column } from '@supabase/react-data-grid';
+import { CalculatedColumn } from '@supabase/react-data-grid';
 import { cloneColumn, getInitialGridColumns } from '../../utils';
 import { INIT_ACTIONTYPE } from './base';
 
 export interface ColumnInitialState {
-  gridColumns: Column<any, any>[];
+  gridColumns: CalculatedColumn <any, any>[];
 }
 
 export const columnInitialState: ColumnInitialState = {
@@ -28,6 +28,10 @@ type COLUMN_ACTIONTYPE =
   | {
       type: 'UNFREEZE_COLUMN';
       payload: { columnKey: string };
+    }
+  | {
+      type: 'UPDATE_COLUMN_IDX';
+      payload: { columnKey: string; columnIdx: number };
     };
 
 const ColumnReducer = (
@@ -96,6 +100,20 @@ const ColumnReducer = (
         gridColumns: update(state.gridColumns, {
           [columnIdx]: { $set: updated },
         }),
+      };
+    }
+    case 'UPDATE_COLUMN_IDX': {
+      const index = state.gridColumns.findIndex(
+        x => x.key === action.payload.columnKey
+      );
+      const updated = cloneColumn(state.gridColumns[index]);
+      updated.idx = action.payload.columnIdx;
+      return {
+        ...state,
+        gridColumns: update(state.gridColumns, {
+          [index]: { $set: updated },
+        })
+        .sort((a, b) => a.idx - b.idx),
       };
     }
     default:

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -1,4 +1,4 @@
-import { Column, HeaderRendererProps } from '@supabase/react-data-grid';
+import { CalculatedColumn, HeaderRendererProps } from '@supabase/react-data-grid';
 
 export interface Dictionary<T> {
   [Key: string]: T;
@@ -30,7 +30,7 @@ export interface Filter {
 
 export interface SavedState {
   filters: Filter[];
-  gridColumns: Column<any, any>[];
+  gridColumns: CalculatedColumn<any, any>[];
   sorts: Sort[];
 }
 

--- a/src/utils/column.ts
+++ b/src/utils/column.ts
@@ -1,9 +1,9 @@
-import { Column } from '@supabase/react-data-grid';
+import { CalculatedColumn } from '@supabase/react-data-grid';
 import { ADD_COLUMN_KEY, SELECT_COLUMN_KEY } from '../constants';
 import { SavedState } from '../types';
 import { deepClone } from './common';
 
-export function cloneColumn(column: Column<any, any>) {
+export function cloneColumn(column: CalculatedColumn<any, any>) {
   const cloned = deepClone(column);
   // these properties can't be cloned. Need to manual re-set again
   cloned.editor = column.editor;
@@ -13,7 +13,7 @@ export function cloneColumn(column: Column<any, any>) {
 }
 
 export function getInitialGridColumns(
-  gridColumns: Column<any, any>[],
+  gridColumns: CalculatedColumn<any, any>[],
   savedState?: SavedState
 ) {
   let result = gridColumns;

--- a/src/utils/gridColumns.tsx
+++ b/src/utils/gridColumns.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Column } from '@supabase/react-data-grid';
+import { CalculatedColumn } from '@supabase/react-data-grid';
 import { ColumnType, SupaColumn, SupaRow, SupaTable } from '../types';
 import {
   isArrayColumn,
@@ -42,15 +42,19 @@ export function getGridColumns(
     onAddColumn?: () => void;
   }
 ): any[] {
-  const columns = table.columns.map((x) => {
+  const columns = table.columns.map((x, idx) => {
     const columnType = getColumnType(x);
-    const columnDefinition: Column<SupaRow> = {
+    const columnDefinition: CalculatedColumn<SupaRow> = {
       key: x.name,
       name: x.name,
+      idx: idx + 1,
       resizable: true,
+      sortable: true,
       width: options?.defaultWidth || getColumnWidth(x),
       minWidth: COLUMN_MIN_WIDTH,
-      frozen: x.isPrimaryKey,
+      frozen: x.isPrimaryKey || false,
+      isLastFrozenColumn: false,
+      rowGroup: false,
       headerRenderer: (props) => (
         <ColumnHeader
           {...props}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix #103. The column order in `state.gridColumns` is not in sync with DataGrid component after doing column freeze/unfreeze. This PR will do 2 things:

1. Replace item type in `state.gridColumns` from `Column` to `CalculatedColumn`, which has `idx` property to indicate each column's order.
2. Add `UPDATE_COLUMN_IDX` state action, which will update column index according to DataGrid component's column index and sort all columns in `state.gridColumns` based on that.

## What is the current behavior?

The column order in state.gridColumns is not correct after doing column freeze/unfreeze. This issue also caused https://github.com/supabase/supabase/issues/4453.

## What is the new behavior?

The column order in state.gridColumns will in sync with DataGrid component.

## Additional context

N/A
