### PR TITLE
fix: display JSON field data

### DIFF
--- a/src/components/common/ForeignTableModal/RowItem.tsx
+++ b/src/components/common/ForeignTableModal/RowItem.tsx
@@ -5,15 +5,15 @@ import { Dictionary } from '../../../types';
 interface RowItemProps {
   item: Dictionary<any>;
   onSelect: (item: Dictionary<any>) => void;
+  columnNames: string[],
 }
 
-export const RowItem: React.FC<RowItemProps> = ({ item, onSelect }) => {
-  const keys = Object.keys(item);
+export const RowItem: React.FC<RowItemProps> = ({ item, onSelect, columnNames }) => {
   return (
     <div className="foreign-table-modal__row-item">
-      <Menu.Item onClick={() => onSelect(item)}>
+      <Menu.Item onClick={() => onSelect(item)} style={{minWidth: 'min-content'}}>
         <div className="foreign-table-modal__row-item__inner">
-          {keys.map((key, j) => {
+          {columnNames.map((key, j) => {
             //
             // limit to 5 attributes
             //
@@ -34,7 +34,7 @@ export const RowItem: React.FC<RowItemProps> = ({ item, onSelect }) => {
                   {key}
                 </Typography.Text>
                 <Typography.Text small strong>
-                  {item[key] || '[null]'}
+                  {item[key] ? (typeof item[key] === 'object') ? JSON.stringify(item[key]) : item[key] : '[null]'}
                 </Typography.Text>
               </div>
             );

--- a/src/components/common/ForeignTableModal/index.tsx
+++ b/src/components/common/ForeignTableModal/index.tsx
@@ -113,7 +113,7 @@ export const ForeignTableModal: React.FC<ForeignTableModalProps> = ({
   function renderRows() {
     if (!rows) return null;
     const temp = rows.map((x, i) => {
-      return <RowItem key={`menu-${i}`} item={x} onSelect={onItemSelect} />;
+      return <RowItem key={`menu-${i}`} item={x} onSelect={onItemSelect} columnNames={foreignColumnNames} />;
     });
     return <Menu className="foreign-table-modal__menu">{temp}</Menu>;
   }

--- a/src/style.css
+++ b/src/style.css
@@ -367,7 +367,7 @@
 }
 
 .foreign-table-modal__row-item {
-  @apply border border-solid dark:border-dark rounded shadow-sm first:mt-2 overflow-hidden;
+  @apply border border-solid dark:border-dark rounded shadow-sm first:mt-2 overflow-hidden overflow-x-scroll;
 }
 
 .foreign-table-modal__row-item__inner {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bugfix 

## What is the current behavior?

Foreign table modal crashes when a field contains JSON data. 

Fixes #113 
## What is the new behavior?

The modal can display JSON data and is X-scrollable. Also, table columns are displayed in the original order.

<img width="576" alt="image" src="https://user-images.githubusercontent.com/51073515/153529772-6144d49a-6868-4d51-9719-dd88e87915aa.png">

## Additional context

Add any other context or screenshots.
