### PR TITLE
fix: in filter not support comma

### DIFF
--- a/example/next-env.d.ts
+++ b/example/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/src/query/Query.utils.ts
+++ b/src/query/Query.utils.ts
@@ -158,8 +158,13 @@ function applyFilters(query: string, filters: Filter[]) {
 }
 
 function inFilterSql(filter: Filter) {
-  const filterValueTxt = String(filter.value);
-  const values = filterValueTxt.split(',').map((x: any) => filterLiteral(x));
+  let values;
+  if (Array.isArray(filter.value)) {
+    values = filter.value.map((x: any) => filterLiteral(x));
+  } else {
+    const filterValueTxt = String(filter.value);
+    values = filterValueTxt.split(',').map((x: any) => filterLiteral(x));
+  }
   return `${ident(filter.column)} ${filter.operator} (${values.join(',')})`;
 }
 

--- a/src/services/row/SqlRowService.ts
+++ b/src/services/row/SqlRowService.ts
@@ -51,8 +51,9 @@ export class SqlRowService implements IRowService {
     let queryChains = this.query
       .from(this.table.name, this.table.schema ?? undefined)
       .delete();
+
     primaryKeys!.forEach((key) => {
-      const primaryKeyValues = rows.map((x) => x[key]).join(',');
+      const primaryKeyValues = rows.map((x) => x[key]);
       queryChains = queryChains.filter(key, 'in', primaryKeyValues);
     });
 

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -1,4 +1,7 @@
-import { CalculatedColumn, HeaderRendererProps } from '@supabase/react-data-grid';
+import {
+  CalculatedColumn,
+  HeaderRendererProps,
+} from '@supabase/react-data-grid';
 
 export interface Dictionary<T> {
   [Key: string]: T;

--- a/test/__snapshots__/query.delete.test.ts.snap
+++ b/test/__snapshots__/query.delete.test.ts.snap
@@ -4,4 +4,6 @@ exports[`basic delete on table 1`] = `"delete from public.users where name = 'he
 
 exports[`delete should ignore order 1`] = `"delete from public.users where name = 'hello world' returning *;"`;
 
+exports[`delete with comma symbol on filter value 1`] = `"delete from public.users where name in ('John, Bob and Billy','Marry, Jane and Fill');"`;
+
 exports[`delete with returning record on table 1`] = `"delete from public.users where name = 'hello world' returning *;"`;

--- a/test/query.delete.test.ts
+++ b/test/query.delete.test.ts
@@ -32,3 +32,11 @@ test('delete should ignore order', async () => {
     .toSql();
   expect(res).toMatchSnapshot();
 });
+test('delete with comma symbol on filter value', async () => {
+  const res = query
+    .from('users')
+    .delete()
+    .filter('name', 'in', ['John, Bob and Billy', 'Marry, Jane and Fill'])
+    .toSql();
+  expect(res).toMatchSnapshot();
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix: in filter not support comma

## What is the current behavior?

#117

## What is the new behavior?

- `in` filter supports array value
- on delete, we create `in` filter with array value
